### PR TITLE
fix(Set Values): correct TweakDB paths (Zeatech -> Zetatech, Legenary -> Legendary)

### DIFF
--- a/PLR2.0/packed/bin/x64/plugins/cyber_engine_tweaks/mods/PLR2.0/modules/Set Values.lua
+++ b/PLR2.0/packed/bin/x64/plugins/cyber_engine_tweaks/mods/PLR2.0/modules/Set Values.lua
@@ -230,9 +230,9 @@ function PLR:new()
 
 
 	--ZETATECH NORMAL ATTACK RANGE STUFF
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundRare.range", settings.NewZetatechBounceRoundRareRange)
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundEpic.range", settings.NewZetatechBounceRoundEpicRange)
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundLegendary.range", settings.NewZetatechBounceRoundLegendaryRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundRare.range", settings.NewZetatechBounceRoundRareRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundEpic.range", settings.NewZetatechBounceRoundEpicRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundLegendary.range", settings.NewZetatechBounceRoundLegendaryRange)
 
 
 	--EPIC LAUNCHER ROUNDS NORMAL ATTACK RANGE
@@ -245,7 +245,7 @@ function PLR:new()
 	--LEGENDARY LAUNCHER ROUNDS NORMAL ATTACK RANGE
 	TweakDB:SetFlat("Attacks.MissileProjectileLegendary.range", settings.NewMissileProjectileLegendaryRange)
 	TweakDB:SetFlat("Attacks.EMPProjectileLegendary.range", settings.NewEMPProjectileLegendaryRange)
-	TweakDB:SetFlat("Attacks.ThermalProjectileLegenary.range", settings.NewThermalProjectileLegendaryRange)
+	TweakDB:SetFlat("Attacks.ThermalProjectileLegendary.range", settings.NewThermalProjectileLegendaryRange)
 	TweakDB:SetFlat("Attacks.ChemicalProjectileLegendary.range", settings.NewChemicalProjectileLegendaryRange)
 
 
@@ -276,9 +276,9 @@ function PLR:new()
 
 
 	--ZETATECH charged ATTACK RANGE STUFF
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundRareCharged.range", settings.NewZetatechBounceRoundRareChargedRange)
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundEpicCharged.range", settings.NewZetatechBounceRoundEpicChargedRange)
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundLegendaryCharged.range", settings.NewZetatechBounceRoundLegendaryChargedRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundRareCharged.range", settings.NewZetatechBounceRoundRareChargedRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundEpicCharged.range", settings.NewZetatechBounceRoundEpicChargedRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundLegendaryCharged.range", settings.NewZetatechBounceRoundLegendaryChargedRange)
 
 
 	--EPIC LAUNCHER ROUNDS charged ATTACK RANGE
@@ -291,7 +291,7 @@ function PLR:new()
 	--LEGENDARY LAUNCHER ROUNDS charged ATTACK RANGE
 	TweakDB:SetFlat("Attacks.MissileProjectileLegendaryCharged.range", settings.NewMissileProjectileLegendaryChargedRange)
 	TweakDB:SetFlat("Attacks.EMPProjectileLegendaryCharged.range", settings.NewEMPProjectileLegendaryChargedRange)
-	TweakDB:SetFlat("Attacks.ThermalProjectileLegenaryCharged.range", settings.NewThermalProjectileLegendaryChargedRange)
+	TweakDB:SetFlat("Attacks.ThermalProjectileLegendaryCharged.range", settings.NewThermalProjectileLegendaryChargedRange)
 	TweakDB:SetFlat("Attacks.ChemicalProjectileLegendaryCharged.range", settings.NewChemicalProjectileLegendaryChargedRange)
 
 

--- a/PLR2.0/source/resources/bin/x64/plugins/cyber_engine_tweaks/mods/PLR2.0/modules/Set Values.lua
+++ b/PLR2.0/source/resources/bin/x64/plugins/cyber_engine_tweaks/mods/PLR2.0/modules/Set Values.lua
@@ -230,9 +230,9 @@ function PLR:new()
 
 
 	--ZETATECH NORMAL ATTACK RANGE STUFF
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundRare.range", settings.NewZetatechBounceRoundRareRange)
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundEpic.range", settings.NewZetatechBounceRoundEpicRange)
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundLegendary.range", settings.NewZetatechBounceRoundLegendaryRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundRare.range", settings.NewZetatechBounceRoundRareRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundEpic.range", settings.NewZetatechBounceRoundEpicRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundLegendary.range", settings.NewZetatechBounceRoundLegendaryRange)
 
 
 	--EPIC LAUNCHER ROUNDS NORMAL ATTACK RANGE
@@ -245,7 +245,7 @@ function PLR:new()
 	--LEGENDARY LAUNCHER ROUNDS NORMAL ATTACK RANGE
 	TweakDB:SetFlat("Attacks.MissileProjectileLegendary.range", settings.NewMissileProjectileLegendaryRange)
 	TweakDB:SetFlat("Attacks.EMPProjectileLegendary.range", settings.NewEMPProjectileLegendaryRange)
-	TweakDB:SetFlat("Attacks.ThermalProjectileLegenary.range", settings.NewThermalProjectileLegendaryRange)
+	TweakDB:SetFlat("Attacks.ThermalProjectileLegendary.range", settings.NewThermalProjectileLegendaryRange)
 	TweakDB:SetFlat("Attacks.ChemicalProjectileLegendary.range", settings.NewChemicalProjectileLegendaryRange)
 
 
@@ -276,9 +276,9 @@ function PLR:new()
 
 
 	--ZETATECH charged ATTACK RANGE STUFF
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundRareCharged.range", settings.NewZetatechBounceRoundRareChargedRange)
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundEpicCharged.range", settings.NewZetatechBounceRoundEpicChargedRange)
-	TweakDB:SetFlat("Attacks.ZeatechBounceRoundLegendaryCharged.range", settings.NewZetatechBounceRoundLegendaryChargedRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundRareCharged.range", settings.NewZetatechBounceRoundRareChargedRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundEpicCharged.range", settings.NewZetatechBounceRoundEpicChargedRange)
+	TweakDB:SetFlat("Attacks.ZetatechBounceRoundLegendaryCharged.range", settings.NewZetatechBounceRoundLegendaryChargedRange)
 
 
 	--EPIC LAUNCHER ROUNDS charged ATTACK RANGE
@@ -291,7 +291,7 @@ function PLR:new()
 	--LEGENDARY LAUNCHER ROUNDS charged ATTACK RANGE
 	TweakDB:SetFlat("Attacks.MissileProjectileLegendaryCharged.range", settings.NewMissileProjectileLegendaryChargedRange)
 	TweakDB:SetFlat("Attacks.EMPProjectileLegendaryCharged.range", settings.NewEMPProjectileLegendaryChargedRange)
-	TweakDB:SetFlat("Attacks.ThermalProjectileLegenaryCharged.range", settings.NewThermalProjectileLegendaryChargedRange)
+	TweakDB:SetFlat("Attacks.ThermalProjectileLegendaryCharged.range", settings.NewThermalProjectileLegendaryChargedRange)
 	TweakDB:SetFlat("Attacks.ChemicalProjectileLegendaryCharged.range", settings.NewChemicalProjectileLegendaryChargedRange)
 
 


### PR DESCRIPTION
## Summary

Per #19, eight TweakDB:SetFlat() calls in the 'range' section of \`Set Values.lua\` referenced non-existent records due to typos:

- 6x \`Attacks.ZeatechBounceRound*\` -> \`Attacks.ZetatechBounceRound*\` (missing 't')
- 2x \`Attacks.ThermalProjectileLegenary[Charged].range\` -> \`Attacks.ThermalProjectileLegendary[Charged].range\` (missing 'd')

With the typos, \`TweakDB:SetFlat()\` silently no-ops, so custom-configured ranges for those rounds never took effect. The damage sections already used the correct spelling.

Applied the same fix to the \`packed/\` copy of \`Set Values.lua\` so the shipped mod stays in sync with source.

Left \`Native Settings Integration.lua\` and \`new_projectile_launcher_round_attacks.yaml\` alone for now — verified grep confirms they don't contain these typos. Happy to follow up if another scan turns something up.

Closes #19

## Testing

\`grep -rn 'Zeatech\\|Legenary' --include='*.lua' --include='*.yaml' .\` returns no hits after the change.